### PR TITLE
fix(uvu): check for process.browser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const context = (state) => ({ tests:[], before:[], after:[], bEach:[], aEach:[],
 const milli = arr => (arr[0]*1e3 + arr[1]/1e6).toFixed(2) + 'ms';
 const hook = (ctx, key) => handler => ctx[key].push(handler);
 
-if (isNode = typeof process !== 'undefined') {
+if (isNode = typeof process !== 'undefined' && !process.browser) {
 	// globalThis polyfill; Node < 12
 	if (typeof globalThis !== 'object') {
 		Object.defineProperty(global, 'globalThis', {


### PR DESCRIPTION
Snowpack defines `process` and `process.browser`. Thus, while running in the browser, uvu takes the branch that should only run in Node.js. This PR adds an additional check for `process.browser`, which fixes the issue.